### PR TITLE
feat: support License-Expression parsing (PEP 639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### 6.0.0
+
+* Added support for `License-Expression` metadata field, see [PEP 639](https://peps.python.org/pep-0639/)
+* Added `--from=expression` option
+* Breaking change: The `--from=all` output now includes the `License-Expression` value
+
 ### 5.0.0
 
 * Dropped support Python 3.8

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -625,6 +625,9 @@ def select_license_by_source(
     license_meta: str,
     license_expression: str,
 ) -> set[str]:
+    if license_expression != LICENSE_UNKNOWN:
+        return {license_expression}
+
     license_classifier_set = set(license_classifier) or {LICENSE_UNKNOWN}
     if (
         from_source == FromArg.CLASSIFIER
@@ -632,14 +635,8 @@ def select_license_by_source(
         and len(license_classifier) > 0
     ):
         return license_classifier_set
-    elif (
-        from_source == FromArg.META
-        or from_source == FromArg.MIXED
-        and license_meta != LICENSE_UNKNOWN
-    ):
-        return {license_meta}
     else:
-        return {license_expression}
+        return {license_meta}
 
 
 def get_output_fields(args: CustomNamespace) -> list[str]:

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -222,9 +222,7 @@ class TestGetLicenses(CommandLineTestCase):
 
         license_columns = self._create_license_columns(table, output_fields)
         license_notation_as_expression = "MIT"
-        # TODO enable assert once a dependency uses 'License-Expression'
-        # TODO (maybe black)
-        # self.assertIn(license_notation_as_expression, license_columns)
+        self.assertIn(license_notation_as_expression, license_columns)
 
     def test_from_all(self) -> None:
         from_args = ["--from=all"]
@@ -259,10 +257,8 @@ class TestGetLicenses(CommandLineTestCase):
             "Apache Software License",
         ):
             self.assertIn(license_name, license_classifier)
-        # TODO enable assert once a dependency uses 'License-Expression'
-        # TODO (maybe black)
-        # for license_name in ("MIT",):
-        #     self.assertIn(license_name, license_expression)
+        for license_name in ("MIT",):
+            self.assertIn(license_name, license_expression)
 
     def test_find_license_from_classifier(self) -> None:
         classifiers = ["License :: OSI Approved :: MIT License"]

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -222,7 +222,9 @@ class TestGetLicenses(CommandLineTestCase):
 
         license_columns = self._create_license_columns(table, output_fields)
         license_notation_as_expression = "MIT"
-        self.assertIn(license_notation_as_expression, license_columns)
+        # TODO enable assert once a dependency uses 'License-Expression'
+        # TODO (maybe black)
+        # self.assertIn(license_notation_as_expression, license_columns)
 
     def test_from_all(self) -> None:
         from_args = ["--from=all"]
@@ -257,8 +259,10 @@ class TestGetLicenses(CommandLineTestCase):
             "Apache Software License",
         ):
             self.assertIn(license_name, license_classifier)
-        for license_name in ("MIT",):
-            self.assertIn(license_name, license_expression)
+        # TODO enable assert once a dependency uses 'License-Expression'
+        # TODO (maybe black)
+        # for license_name in ("MIT",):
+        #     self.assertIn(license_name, license_expression)
 
     def test_find_license_from_classifier(self) -> None:
         classifiers = ["License :: OSI Approved :: MIT License"]

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -337,6 +337,15 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertEqual(
             {"Apache-2.0"},
             select_license_by_source(
+                FromArg.MIXED,
+                ["Apache License 2.0"],
+                "Apache",
+                "Apache-2.0",
+            ),
+        )
+        self.assertEqual(
+            {"Apache-2.0"},
+            select_license_by_source(
                 FromArg.EXPRESSION,
                 ["Apache License 2.0"],
                 "Apache",

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -212,6 +212,20 @@ class TestGetLicenses(CommandLineTestCase):
         license_notation_as_classifier = "MIT License"
         self.assertIn(license_notation_as_classifier, license_columns)
 
+    def test_from_expression(self) -> None:
+        from_args = ["--from=expression"]
+        args = self.parser.parse_args(from_args)
+        output_fields = get_output_fields(args)
+        table = create_licenses_table(args, output_fields)
+
+        self.assertIn("License", output_fields)
+
+        license_columns = self._create_license_columns(table, output_fields)
+        license_notation_as_expression = "MIT"
+        # TODO enable assert once a dependency uses 'License-Expression'
+        # TODO (maybe black)
+        # self.assertIn(license_notation_as_expression, license_columns)
+
     def test_from_all(self) -> None:
         from_args = ["--from=all"]
         args = self.parser.parse_args(from_args)
@@ -220,6 +234,7 @@ class TestGetLicenses(CommandLineTestCase):
 
         self.assertIn("License-Metadata", output_fields)
         self.assertIn("License-Classifier", output_fields)
+        self.assertIn("License-Expression", output_fields)
 
         index_license_meta = output_fields.index("License-Metadata")
         license_meta = []
@@ -231,6 +246,11 @@ class TestGetLicenses(CommandLineTestCase):
         for row in table.rows:
             license_classifier.append(row[index_license_classifier])
 
+        index_license_expression = output_fields.index("License-Expression")
+        license_expression = [
+            row[index_license_expression] for row in table.rows
+        ]
+
         for license_name in ("BSD", "MIT", "Apache 2.0"):
             self.assertIn(license_name, license_meta)
         for license_name in (
@@ -239,6 +259,10 @@ class TestGetLicenses(CommandLineTestCase):
             "Apache Software License",
         ):
             self.assertIn(license_name, license_classifier)
+        # TODO enable assert once a dependency uses 'License-Expression'
+        # TODO (maybe black)
+        # for license_name in ("MIT",):
+        #     self.assertIn(license_name, license_expression)
 
     def test_find_license_from_classifier(self) -> None:
         classifiers = ["License :: OSI Approved :: MIT License"]
@@ -270,27 +294,53 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertEqual(
             {"MIT License"},
             select_license_by_source(
-                FromArg.CLASSIFIER, ["MIT License"], "MIT"
+                FromArg.CLASSIFIER, ["MIT License"], "MIT", LICENSE_UNKNOWN
             ),
         )
 
         self.assertEqual(
             {LICENSE_UNKNOWN},
-            select_license_by_source(FromArg.CLASSIFIER, [], "MIT"),
+            select_license_by_source(
+                FromArg.CLASSIFIER, [], "MIT", LICENSE_UNKNOWN
+            ),
         )
 
         self.assertEqual(
             {"MIT License"},
-            select_license_by_source(FromArg.MIXED, ["MIT License"], "MIT"),
+            select_license_by_source(
+                FromArg.MIXED, ["MIT License"], "MIT", LICENSE_UNKNOWN
+            ),
         )
 
         self.assertEqual(
-            {"MIT"}, select_license_by_source(FromArg.MIXED, [], "MIT")
+            {"MIT"},
+            select_license_by_source(
+                FromArg.MIXED, [], "MIT", LICENSE_UNKNOWN
+            ),
         )
         self.assertEqual(
             {"Apache License 2.0"},
             select_license_by_source(
-                FromArg.MIXED, ["Apache License 2.0"], "Apache-2.0"
+                FromArg.MIXED,
+                ["Apache License 2.0"],
+                "Apache-2.0",
+                LICENSE_UNKNOWN,
+            ),
+        )
+
+        self.assertEqual(
+            {"MIT"},
+            select_license_by_source(
+                FromArg.MIXED, [], LICENSE_UNKNOWN, "MIT"
+            ),
+        )
+        self.assertEqual(
+            {"Apache-2.0"},
+            select_license_by_source(
+                FromArg.EXPRESSION,
+                ["Apache License 2.0"],
+                "Apache",
+                "Apache-2.0",
             ),
         )
 


### PR DESCRIPTION
Leveraging https://github.com/raimon49/pip-licenses/pull/213 to handle PEP 639.

---

**Original PR content:**

[PEP 639](https://peps.python.org/pep-0639/) has been (provisionally) accepted recently. `hatch` added support[1](https://github.com/raimon49/pip-licenses/pull/213#user-content-fn-1-2206165f68ed2e873395acbda8570ce4) for it early on and so the first packages which store the license metadata inside the `License-Expression` field start popping up. E.g. for [ftfy](https://pypi.org/project/ftfy/) it looks like this

```
...
License-Expression: Apache-2.0
License-File: LICENSE.txt
...
```

This PR adds the basic parsing support without any validation similar to the existing behavior for the `License` metadata field or the classifier. It might make sense to add the validation at a later point though.

To keep the changes to a minimum, the behavior of `--from=mixed` is preserved. However:



> [!CAUTION]
Breaking change: The `--from=all` output now includes the `License-Expression` value.

Fixes https://github.com/raimon49/pip-licenses/issues/225

Footnotes
https://hatch.pypa.io/1.9/config/metadata/#spdx-expression [↩](https://github.com/raimon49/pip-licenses/pull/213#user-content-fnref-1-2206165f68ed2e873395acbda8570ce4)